### PR TITLE
Fix asset upload and heartbeat calls, cleanup naming conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,15 +100,6 @@ venv.bak/
 # mypy
 .mypy_cache/
 
-# Our DSL tool creates these
-kube_deployment-*.yaml
-kube_namespace-*.yaml
-kube_secret-*.yaml
-kube_service-*.yaml
-marathon-*.json
-metronome-*.json
-kongfig-*.json
-
 ### IntelliJ IDEA ###
 .idea
 *.iws
@@ -119,8 +110,8 @@ kongfig-*.json
 .vscode/
 
 ### app specific ###
-# local db (pre-UI, or run as CLI)
-app/chat/*.db
+provider_session_links.txt
+
 
 ### mac stuff 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ brew install pipenv   # installs pipenv
 export PIPENV_VENV_IN_PROJECT=1
 pipenv install        # installs python dependencies into pipenv
 pipenv install --dev  # installs python dev-dependencies into pipenv
-pipenv run playwright install  # installs playwright browser binaries
 ```
 
 Add this to your .bashrc/.zshrc to stick python virtualenv to project directory.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,4 @@ Issues = "https://github.com/ApplauseOSS/common-python-reporter/issues"
 addopts = [
     "--import-mode=importlib",
 ]
-pythonpath = "src/applause/common_python_reporter"
+pythonpath = "src"

--- a/src/applause/common_python_reporter/auto_api.py
+++ b/src/applause/common_python_reporter/auto_api.py
@@ -203,7 +203,7 @@ class AutoApi:
         headers = {"X-Api-Key": self.config.api_key}
         requests.post(
             f"{self.config.auto_api_base_url}api/v2.0/sdk-heartbeat",
-            json={"testRunId", test_run_id},
+            json={"testRunId": test_run_id},
             headers=headers,
         )
 
@@ -270,10 +270,10 @@ class AutoApi:
         requests.post(
             f"{self.config.auto_api_base_url}api/v1.0/test-result/{result_id}/upload",
             headers=headers,
-            files={file: file},
+            files={"file": (asset_name, file, "application/octet-stream")},
             data={
                 "providerSessionGuid": provider_session_guid,
-                "assetType": asset_type,
+                "assetType": asset_type.value,
                 "assetName": asset_name,
             },
         )

--- a/src/applause/common_python_reporter/dtos.py
+++ b/src/applause/common_python_reporter/dtos.py
@@ -93,6 +93,7 @@ class TestResultStatus(str, Enum):
     """
 
     __test__ = False
+    model_config = ConfigDict(use_enum_values=True)
     NOT_RUN = "NOT_RUN"
     IN_PROGRESS = "IN_PROGRESS"
     PASSED = "PASSED"
@@ -116,8 +117,8 @@ class TestResultProviderInfo(BaseModel):
     __test__ = False
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
     test_result_id: int
-    provider_url: str
-    provider_session_id: str
+    provider_url: Optional[str] = None
+    provider_session_id: Optional[str] = None
 
 
 class TestRailOptions(BaseModel):
@@ -184,6 +185,7 @@ class SubmitTestCaseResultDto(BaseModel):
 
     """
 
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
     test_result_id: int
     status: TestResultStatus
     provider_session_guids: List[str]
@@ -211,6 +213,8 @@ class AssetType(str, Enum):
         PAGE_SOURCE: A page source asset
         UNKNOWN: An unknown asset
     """
+
+    model_config = ConfigDict(use_enum_values=True)
 
     SCREENSHOT = "SCREENSHOT"
     FAILURE_SCREENSHOT = "FAILURE_SCREENSHOT"

--- a/src/applause/common_python_reporter/public_api.py
+++ b/src/applause/common_python_reporter/public_api.py
@@ -50,12 +50,12 @@ class SessionDetailsValue(BaseModel):
     """
 
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
-    deviceName: Optional[str]
-    orientation: Optional[str]
-    platformName: Optional[str]
-    platformVersion: Optional[str]
-    browserName: Optional[str]
-    browserVersion: Optional[str]
+    deviceName: Optional[str] = None
+    orientation: Optional[str] = None
+    platformName: Optional[str] = None
+    platformVersion: Optional[str] = None
+    browserName: Optional[str] = None
+    browserVersion: Optional[str] = None
 
 
 class SessionDetails(BaseModel):
@@ -89,10 +89,10 @@ class TestRunAutoResultDto(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
     testCycleId: int
     status: TestRunAutoResultStatus
-    failureReason: Optional[str]
-    sessionDetailsJson: Optional[SessionDetails]
-    startTime: Optional[str]
-    endTime: Optional[str]
+    failureReason: Optional[str] = None
+    sessionDetailsJson: Optional[SessionDetails] = None
+    startTime: Optional[str] = None
+    endTime: Optional[str] = None
 
 
 class PublicApi:

--- a/src/applause/common_python_reporter/utils.py
+++ b/src/applause/common_python_reporter/utils.py
@@ -28,8 +28,8 @@ class TestCaseNameMatches(BaseModel):
     __test__ = False
 
     test_case_name: str
-    test_rail_test_case_id: Optional[int]
-    applause_test_case_id: Optional[int]
+    test_rail_test_case_id: Optional[int] = None
+    applause_test_case_id: Optional[int] = None
 
 
 def remove_prefix(text: str, prefix: str) -> str:

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from applause.common_python_reporter.reporter import ApplauseReporter, ApplauseConfig, AutoApi
+from applause.common_python_reporter.dtos import TestRunCreateResponseDto, AssetType, CreateTestCaseResultResponseDto, TestResultStatus
+
+class TestApplauseReporter:
+    @pytest.fixture
+    def reporter(self):
+        with patch('applause.common_python_reporter.auto_api.AutoApi') as auto_api_mock:
+            """Returns a mock AutoApi object"""
+            auto_api_mock.start_test_run = MagicMock(return_value=TestRunCreateResponseDto(run_id=123))
+            auto_api_mock.end_test_run = MagicMock()
+            auto_api_mock.start_test_case = MagicMock(return_value = CreateTestCaseResultResponseDto(test_result_id=456))
+            auto_api_mock.submit_test_case_result = MagicMock()
+            auto_api_mock.get_provider_session_links = MagicMock(return_value = [])
+            auto_api_mock.send_sdk_heartbeat.return_value = MagicMock()
+            auto_api_mock.upload_asset.return_value = MagicMock()
+            reporter = ApplauseReporter(ApplauseConfig(
+                api_key="api-key",
+                product_id=123
+            ))
+            reporter.auto_api = auto_api_mock
+            reporter.initializer.auto_api = auto_api_mock
+            yield reporter
+
+    def test_runner_start(self, reporter: ApplauseReporter):
+        # Test starting a test run
+        run_id = reporter.runner_start(tests=["test1", "test2"])
+        assert run_id == 123
+
+    def test_start_test_case(self, reporter: ApplauseReporter):
+        # Test starting a test case
+        reporter.runner_start()
+        result = reporter.start_test_case("test1", "Test Case 1")
+        assert result.test_result_id == 456
+
+    def test_submit_test_case_result(self, reporter: ApplauseReporter):
+        # Test submitting a test case result
+        reporter.runner_start()
+        reporter.start_test_case("test1", "Test Case 1")
+        reporter.submit_test_case_result("test1", TestResultStatus.PASSED)
+
+    def test_runner_end(self, reporter: ApplauseReporter):
+        # Test ending a test run
+        reporter.runner_start(tests=["test1", "test2"])
+        reporter.runner_end()
+
+    def test_attach_test_case_asset(self, reporter: ApplauseReporter):
+        # Test attaching an asset to a test case
+        reporter.runner_start()
+        reporter.start_test_case("test1", "Test Case 1")
+        reporter.attach_test_case_asset("test1", "asset.png", "123456", AssetType.SCREENSHOT, b"...")


### PR DESCRIPTION
### What changed?
- Fix multi-part http call for asset upload
- Fix heartbeat call to use dict instead of set
- Add provider_session_links.txt to .gitignore
- Fix project.toml python path
- Add missing pydantic model_config for DTOs
- Set Optional values to None
- Fix naming conventions of test case properties