### PR TITLE
Add itw test cycle id to create run call

### DIFF
--- a/src/applause/common_python_reporter/auto_api.py
+++ b/src/applause/common_python_reporter/auto_api.py
@@ -83,6 +83,7 @@ class AutoApi:
         request_params = params.model_dump(by_alias=True)
         request_params["productId"] = self.config.product_id
         request_params["sdkVersion"] = f"python:{self.api_version}"
+        request_params["itwTestCycleId"] = self.config.applause_test_cycle_id
 
         # If testRailOptions is not None, add the testRailReportingEnabled flag and the additional testRailOptions
         if self.config.test_rail_options is not None:

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -15,7 +15,7 @@ class TestApplauseReporter:
         assert create_run_call.call_count == 0
         run_id = reporter.runner_start(tests=["test1", "test2"])
         assert create_run_call.call_count == 1
-        assert create_run_call.calls[0].request.body == b'{"tests": ["test1", "test2"], "productId": 123, "sdkVersion": "python:1.0.0"}', "Create run request Body should be formatted properly"
+        assert create_run_call.calls[0].request.body == b'{"tests": ["test1", "test2"], "productId": 123, "sdkVersion": "python:1.0.0", "itwTestCycleId": null}', "Create run request Body should be formatted properly"
         assert run_id == 123
 
     @responses.activate
@@ -67,7 +67,7 @@ class TestApplauseReporter:
         assert create_run_call.call_count == 0
         reporter.runner_start(tests=["test1", "test2"])
         assert create_run_call.call_count == 1
-        assert create_run_call.calls[0].request.body == b'{"tests": ["test1", "test2"], "productId": 123, "sdkVersion": "python:1.0.0"}', "Create run request Body should be formatted properly"
+        assert create_run_call.calls[0].request.body == b'{"tests": ["test1", "test2"], "productId": 123, "sdkVersion": "python:1.0.0", "itwTestCycleId": null}', "Create run request Body should be formatted properly"
         assert end_run_call.call_count == 0
         assert provider_info_call.call_count == 0
         reporter.runner_end()


### PR DESCRIPTION
### What changed?
Reporting to the applause test cycles was not working as the test cycle id passed in the config was not being propagated to the test run