### PR TITLE
Fix asset upload session id parameter naming

### DIFF
--- a/src/applause/common_python_reporter/auto_api.py
+++ b/src/applause/common_python_reporter/auto_api.py
@@ -305,7 +305,7 @@ class AutoApi:
                 headers=headers,
                 files={"file": (asset_name, file, "application/octet-stream")},
                 data={
-                    "providerSessionGuid": provider_session_guid,
+                    "sessionId": provider_session_guid,
                     "assetType": asset_type.value,
                     "assetName": asset_name,
                 },


### PR DESCRIPTION
### What changed?
Update Asset Upload call to use sessionId instead of providerSessionId